### PR TITLE
Update enrichment details endpoint url

### DIFF
--- a/routes/enrichments/index.js
+++ b/routes/enrichments/index.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 const data = require('../../mock-data/enrichments/entries.json');
 
-router.get('/enrichments/:id', function (req, res) {
+router.get('/enrichments/:type/entries/:id', function (req, res) {
   const id = req.params.id;
   const entry = data.find(entry => entry.uuid === id);
   if (entry) {


### PR DESCRIPTION
NOTE: This branch must be tested with this PR to accommodate the new endpoint: https://github.com/hortonworks/hcp-enrichment_private/pull/8

In this PR, I updated the enrichment details endpoint to utilize both the type and id. This needed to be done because the id won't be unique across multiple tables. In addition, it follows the convention of the PUT request for updating details.

